### PR TITLE
Update README intro to emphasize use alongside other apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stream Deck plugin for [cmux](https://github.com/manaflow-ai/cmux) workspace management.
 
-Turns a Stream Deck into a physical dashboard for cmux: switch workspaces with a tap instead of alt-tabbing or keyboard shortcuts, and see at a glance which workspace is selected and which ones have pending Claude notifications.
+While Claude is working across your cmux workspaces, you're often in a browser reviewing PRs or reading docs. Your Stream Deck shows workspace status and pending notifications, and lets you switch with a single tap — no ⌘-Tab required.
 
 <img src="screenshot-03.jpeg" width="67%">
 


### PR DESCRIPTION
https://claude.ai/code/session_01EWuzn6rqYhYAgpSFgr5jmg

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrite README intro to emphasize using the Stream Deck plugin alongside other apps while Claude works across `cmux` workspaces. Clarifies that the deck shows workspace status and pending notifications, and enables one‑tap switching without ⌘‑Tab.

<sup>Written for commit 88ea66f42d5002b959fc43e3bfa93a1df106db55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

