### PR TITLE
fix: prevent Stream Deck freeze after sleep/wake

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -29,6 +29,15 @@ streamDeck.actions.registerAction(new NewWorkspaceCcq(client));
 streamDeck.actions.registerAction(new SocketToggle(client, poller));
 streamDeck.actions.registerAction(new RestartStreamDeck());
 
+streamDeck.system.onSystemDidWakeUp(() => {
+  log("system woke up, pausing poller");
+  poller.pause();
+  setTimeout(() => {
+    log("resuming poller after wake");
+    poller.start();
+  }, 3000);
+});
+
 log("connecting to stream deck");
 streamDeck.connect();
 log("connect() called");

--- a/src/poller.ts
+++ b/src/poller.ts
@@ -60,10 +60,15 @@ export class Poller {
     void this.poll();
   }
 
-  reset(): void {
+  pause(): void {
     this.generation++;
     this.stop();
     this.lastState = new Map();
+    for (const fn of this.listeners) fn(this.lastState);
+  }
+
+  reset(): void {
+    this.pause();
     this.start();
   }
 


### PR DESCRIPTION
The 100ms animation timer kept firing setImage calls during wake-up, overwhelming the Stream Deck app while it re-established USB connection.

Handle systemDidWakeUp by pausing the poller (which clears state and stops animation), then resuming after 3s to let the app settle.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented Stream Deck freezes after sleep/wake by pausing the poller on wake and resuming after 3s, avoiding image update floods during USB reconnection.

- **Bug Fixes**
  - Handle `systemDidWakeUp` by calling `poller.pause()` to stop animation and clear state.
  - Resume with `poller.start()` after a 3s delay so the app can settle.
  - Added `Poller.pause()` (increments generation, stops, clears state, notifies listeners). Updated `reset()` to use `pause()` then `start()`.

<sup>Written for commit 0672938ced26230e5a6ee1afbc90db83ba55c419. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

