### PR TITLE
fix: reconnect cmux socket on wake to unstick zombie connection

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -30,8 +30,9 @@ streamDeck.actions.registerAction(new SocketToggle(client, poller));
 streamDeck.actions.registerAction(new RestartStreamDeck());
 
 streamDeck.system.onSystemDidWakeUp(() => {
-  log("system woke up, pausing poller");
+  log("system woke up, reconnecting socket and pausing poller");
   poller.pause();
+  client.reconnect(client.getSocketPath());
   setTimeout(() => {
     log("resuming poller after wake");
     poller.start();


### PR DESCRIPTION
After sleep, macOS leaves Unix domain sockets in a half-dead state: the socket reports connected, writes silently succeed, but no data returns and no close/error event fires. The first post-wake send() hung forever on inflight, queuing every subsequent poll behind it.

#7 only paused the poller's animation; it didn't replace the dead socket. Force a fresh connection via client.reconnect() on wake.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconnect the cmux Unix domain socket on system wake to replace zombie connections on macOS and keep polling responsive.

- **Bug Fixes**
  - On wake, pause the poller, call client.reconnect(client.getSocketPath()), then resume after a short delay.
  - Prevents post-wake half-dead sockets where writes succeed but no data returns, causing the first send to hang and blocking polls.

<sup>Written for commit 13ce46acf0777b7309d235b47dbae3e34dd5bed2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

