### PR TITLE
fix: detect cmux socket path from last-socket-path file

### DIFF
--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -2,7 +2,17 @@ import * as net from "net";
 import * as fs from "fs";
 
 export const SOCKET_PATHS = ["/tmp/cmux.sock", "/tmp/cmux-nightly.sock"];
-const DEFAULT_SOCKET_PATH = process.env.CMUX_SOCKET_PATH ?? SOCKET_PATHS[0];
+
+function resolveDefaultSocketPath(): string {
+  if (process.env.CMUX_SOCKET_PATH) return process.env.CMUX_SOCKET_PATH;
+  try {
+    const recorded = fs.readFileSync("/tmp/cmux-last-socket-path", "utf8").trim();
+    if (recorded) return recorded;
+  } catch {}
+  return SOCKET_PATHS[0];
+}
+
+const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 const RECONNECT_DELAY_MS = 2000;
 
 const LOG_PATH = "/tmp/streamdeck-cmux-debug.log";


### PR DESCRIPTION
Fixes #9

## Problem

cmux 0.63.2+ creates the socket at `~/Library/Application Support/cmux/cmux.sock` instead of `/tmp/cmux.sock`. The plugin hardcodes `/tmp/cmux.sock` so it fails to connect and all buttons are non-functional.

## Solution

cmux writes the active socket path to `/tmp/cmux-last-socket-path` on startup. Read that file at plugin startup and use it as the default, falling back to `/tmp/cmux.sock` if the file doesn't exist (preserving backwards compatibility with older cmux versions).

Priority: `CMUX_SOCKET_PATH` env var > `/tmp/cmux-last-socket-path` > `/tmp/cmux.sock`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically detect the active cmux socket path at startup by reading `/tmp/cmux-last-socket-path`, fixing connection failures on cmux 0.63.2+. Falls back to `/tmp/cmux.sock` for older versions.

- **Bug Fixes**
  - Resolve default socket path in order: `CMUX_SOCKET_PATH` env var → `/tmp/cmux-last-socket-path` → `/tmp/cmux.sock`.
  - No other behavior changes.

<sup>Written for commit a60154e27c9a3e486fda77635c8f35236903cb9d. Summary will update on new commits. <a href="https://cubic.dev/pr/gonzaloserrano/streamdeck-cmux/pull/10?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

