### PR TITLE
fix: prioritize user key presses over background poll commands

### DIFF
--- a/src/actions/workspace-button.ts
+++ b/src/actions/workspace-button.ts
@@ -72,7 +72,7 @@ export class WorkspaceButton extends SingletonAction<Settings> {
     const appName = this.client.getSocketPath().includes("nightly") ? "cmux NIGHTLY" : "cmux";
     execFile("osascript", ["-e", `tell application "${appName}" to activate`]);
     try {
-      const result = await this.client.send(`select_workspace ${ws.id}`);
+      const result = await this.client.sendPriority(`select_workspace ${ws.id}`);
       debugLog(`select_workspace result: ${result}`);
       this.poller.forcePoll();
     } catch (err) {

--- a/src/cmux-client.ts
+++ b/src/cmux-client.ts
@@ -157,6 +157,14 @@ export class CmuxClient {
     });
   }
 
+  /** Send a command ahead of any queued poll commands. */
+  sendPriority(command: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.queue.unshift({ command, resolve, reject });
+      this.drain();
+    });
+  }
+
   destroy(): void {
     this.destroyed = true;
     this.cancelSettle();


### PR DESCRIPTION
## Problem

Pressing a workspace button felt slow (1-3 second delay before the workspace switched). The `select_workspace` command was appended to the back of the command queue, behind any in-progress `list_workspaces` + `sidebar_state` poll commands.

## Solution

Add `sendPriority()` to `CmuxClient` which unshifts the command to the front of the queue instead of pushing to the back. Use it for `select_workspace` so key presses are dispatched as soon as the current in-flight command completes, ahead of any queued poll commands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritizes workspace switch commands so key presses run immediately, removing the 1–3s delay caused by queued background polls. Adds a priority send path and uses it for `select_workspace`.

- **Bug Fixes**
  - Added `sendPriority()` in the client to put commands at the front of the queue.
  - Updated workspace button to send `select_workspace` via priority, ahead of `list_workspaces` and `sidebar_state` polls.

<sup>Written for commit 2fb5aeb371377b0a0fc4cb5046c213980417ba23. Summary will update on new commits. <a href="https://cubic.dev/pr/gonzaloserrano/streamdeck-cmux/pull/11?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

